### PR TITLE
Remove account_index from API and use AccountId instead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3648,7 +3648,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.5.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "bech32",
  "bs58",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "async-trait",
  "base64",
@@ -3706,7 +3706,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_memory"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "async-trait",
  "bs58",
@@ -3741,7 +3741,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.11.2"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "bs58",
  "byteorder",
@@ -3777,7 +3777,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3786,7 +3786,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "bech32",
  "bip32",
@@ -3827,7 +3827,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "aes",
  "bip32",
@@ -3865,7 +3865,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3885,7 +3885,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "document-features",
  "memuse",
@@ -3954,7 +3954,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4#b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ tokio_with_wasm = { version = "0.7.1", features = ["rt", "rt-multi-thread", "syn
 
 ## Zcash dependencies
 
-zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
-zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
-zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4", features = ["orchard"] }
-zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4" }
-zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4" }
-zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4", default-features = false, features = ["bundled-prover"] }
+zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
+zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
+zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", features = ["orchard"] }
+zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a" }
+zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a" }
+zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["bundled-prover"] }
 
 ## gRPC Web dependencies
 prost = { version = "0.12", default-features = false }
@@ -77,7 +77,7 @@ tonic = { version = "0.12", default-features = false, features = [
 
 # Used in Native tests
 tokio = { version = "1.0" }
-zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "b6d32dd9a57165fb1508e9c1c8ab1a3aba09c7f4", default-features = false, features = ["unstable", "orchard"], optional = true }
+zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["unstable", "orchard"], optional = true }
 
 getrandom = { version = "0.2", features = ["js"] }
 thiserror = "1.0.63"

--- a/packages/demo-wallet/src/App/Actions.tsx
+++ b/packages/demo-wallet/src/App/Actions.tsx
@@ -1,7 +1,7 @@
 import initWasm, { initThreadPool, WebWallet } from "@webzjs/webz-core";
 
 import { State, Action } from "./App";
-import { MAINNET_LIGHTWALLETD_PROXY } from "./constants";
+import { MAINNET_LIGHTWALLETD_PROXY } from "./Constants";
 
 export async function init(dispatch: React.Dispatch<Action>) {
   await initWasm();
@@ -13,8 +13,8 @@ export async function init(dispatch: React.Dispatch<Action>) {
 }
 
 export async function addNewAccount(state: State, dispatch: React.Dispatch<Action>, seedPhrase: string, birthdayHeight: number) {
-    await state.webWallet?.create_account(seedPhrase, 0, birthdayHeight);
-    dispatch({ type: "append-account-seed", payload: seedPhrase });
+    let account_id = await state.webWallet?.create_account(seedPhrase, 0, birthdayHeight) || 0;
+    dispatch({ type: "add-account-seed", payload: [account_id, seedPhrase] });
     await syncStateWithWallet(state, dispatch);
 }
 
@@ -60,6 +60,7 @@ export async function triggerTransfer(
         throw new Error("No active account");
     }
 
-    await state.webWallet?.transfer(state.accountSeeds[state.activeAccount], state.activeAccount, toAddress, amount);
+    let activeAccountSeedPhrase = state.accountSeeds.get(state.activeAccount) || "";
+    await state.webWallet?.transfer(activeAccountSeedPhrase, state.activeAccount, toAddress, amount);
     await syncStateWithWallet(state, dispatch);
 }

--- a/packages/demo-wallet/src/App/App.tsx
+++ b/packages/demo-wallet/src/App/App.tsx
@@ -23,19 +23,19 @@ export type State = {
   activeAccount?: number;
   summary?: WalletSummary;
   chainHeight?: bigint;
-  accountSeeds: string[];
+  accountSeeds: Map<number, string>;
 };
 
 const initialState: State = {
   activeAccount: undefined,
   summary: undefined,
   chainHeight: undefined,
-  accountSeeds: [],
+  accountSeeds: new Map<number, string>(),
 };
 
 export type Action =
   | { type: "set-active-account"; payload: number }
-  | { type: "append-account-seed"; payload: string }
+  | { type: "add-account-seed"; payload: [number, string] }
   | { type: "set-web-wallet"; payload: WebWallet }
   | { type: "set-summary"; payload: WalletSummary }
   | { type: "set-chain-height"; payload: bigint };
@@ -45,8 +45,8 @@ const reducer = (state: State, action: Action): State => {
     case "set-active-account": {
       return { ...state, activeAccount: action.payload };
     }
-    case "append-account-seed": {
-      return { ...state, accountSeeds: [...state.accountSeeds, action.payload] };
+    case "add-account-seed": {
+      return { ...state, accountSeeds: state.accountSeeds.set(action.payload[0], action.payload[1]) };
     }
     case "set-web-wallet": {
       return { ...state, webWallet: action.payload };

--- a/src/bindgen/wallet.rs
+++ b/src/bindgen/wallet.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroU32;
+use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
@@ -6,15 +7,20 @@ use wasm_bindgen::prelude::*;
 use tonic_web_wasm_client::Client;
 
 use crate::error::Error;
-use crate::{BlockRange, MemoryWallet, Wallet, PRUNING_DEPTH};
+use crate::{BlockRange, Wallet, PRUNING_DEPTH};
 use wasm_thread as thread;
 use zcash_address::ZcashAddress;
+use zcash_client_backend::data_api::WalletRead;
 use zcash_client_backend::proto::service::{
     compact_tx_streamer_client::CompactTxStreamerClient, ChainSpec,
 };
 use zcash_client_memory::MemoryWalletDb;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus::{self, BlockHeight};
+
+pub type MemoryWallet<T> = Wallet<MemoryWalletDb<consensus::Network>, T>;
+pub type AccountId =
+    <MemoryWalletDb<zcash_primitives::consensus::Network> as WalletRead>::AccountId;
 
 /// # A Zcash wallet
 ///
@@ -87,30 +93,30 @@ impl WebWallet {
     ///
     /// # Arguments
     /// seed_phrase - mnemonic phrase to initialise the wallet
-    /// account_index - The HD derivation index to use. Can be any integer
+    /// account_hd_index - The HD derivation index to use. Can be any integer
     /// birthday_height - The block height at which the account was created, optionally None and the current height is used
     ///
     pub async fn create_account(
         &self,
         seed_phrase: &str,
-        account_index: u32,
+        account_hd_index: u32,
         birthday_height: Option<u32>,
-    ) -> Result<String, Error> {
+    ) -> Result<u32, Error> {
         tracing::info!("Create account called");
         self.inner
-            .create_account(seed_phrase, account_index, birthday_height)
+            .create_account(seed_phrase, account_hd_index, birthday_height)
             .await
+            .map(|id| *id)
     }
 
-    pub async fn import_ufvk(
-        &self,
-        key: &str,
-        birthday_height: Option<u32>,
-    ) -> Result<String, Error> {
+    pub async fn import_ufvk(&self, key: &str, birthday_height: Option<u32>) -> Result<u32, Error> {
         let ufvk = UnifiedFullViewingKey::decode(&self.inner.network, key)
             .map_err(Error::KeyParseError)?;
 
-        self.inner.import_ufvk(&ufvk, birthday_height).await
+        self.inner
+            .import_ufvk(&ufvk, birthday_height)
+            .await
+            .map(|id| *id)
     }
 
     pub async fn suggest_scan_ranges(&self) -> Result<Vec<BlockRange>, Error> {
@@ -173,13 +179,18 @@ impl WebWallet {
     pub async fn transfer(
         &self,
         seed_phrase: &str,
-        from_account_index: usize,
+        from_account_id: u32,
         to_address: String,
         value: u64,
     ) -> Result<(), Error> {
         let to_address = ZcashAddress::try_from_encoded(&to_address)?;
         self.inner
-            .transfer(seed_phrase, from_account_index, to_address, value)
+            .transfer(
+                seed_phrase,
+                AccountId::from(from_account_id),
+                to_address,
+                value,
+            )
             .await
     }
 

--- a/src/bindgen/wallet.rs
+++ b/src/bindgen/wallet.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroU32;
-use std::ops::Deref;
 
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@ pub mod wallet;
 pub use wallet::Wallet;
 
 use wasm_bindgen::prelude::*;
-use zcash_client_memory::MemoryWalletDb;
-use zcash_primitives::consensus;
 
 /// The maximum number of checkpoints to store in each shard-tree
 pub const PRUNING_DEPTH: usize = 100;
@@ -30,5 +28,3 @@ pub fn init_thread_pool(_threads: usize) {}
 
 #[wasm_bindgen]
 pub struct BlockRange(pub u32, pub u32);
-
-pub type MemoryWallet<T> = Wallet<MemoryWalletDb<consensus::Network>, T>;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -24,8 +24,8 @@ use zcash_client_backend::data_api::wallet::{
 };
 use zcash_client_backend::data_api::{scanning::ScanRange, WalletCommitmentTrees};
 use zcash_client_backend::data_api::{
-    AccountBirthday, AccountPurpose, InputSource, NullifierQuery, WalletRead, WalletSummary,
-    WalletWrite,
+    Account, AccountBirthday, AccountPurpose, InputSource, NullifierQuery, WalletRead,
+    WalletSummary, WalletWrite,
 };
 use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::proposal::Proposal;
@@ -143,17 +143,17 @@ where
     ///
     /// # Arguments
     /// seed_phrase - mnemonic phrase to initialise the wallet
-    /// account_index - The HD derivation index to use. Can be any integer
+    /// account_id - The HD derivation index to use. Can be any integer
     /// birthday_height - The block height at which the account was created, optionally None and the current height is used
     ///
     pub async fn create_account(
         &self,
         seed_phrase: &str,
-        account_index: u32,
+        account_hd_index: u32,
         birthday_height: Option<u32>,
-    ) -> Result<String, Error> {
+    ) -> Result<AccountId, Error> {
         // decode the mnemonic and derive the first account
-        let usk = usk_from_seed_str(seed_phrase, account_index, &self.network)?;
+        let usk = usk_from_seed_str(seed_phrase, account_hd_index, &self.network)?;
         let ufvk = usk.to_unified_full_viewing_key();
 
         tracing::info!("Key successfully decoded. Importing into wallet");
@@ -166,7 +166,7 @@ where
         &self,
         ufvk: &UnifiedFullViewingKey,
         birthday_height: Option<u32>,
-    ) -> Result<String, Error> {
+    ) -> Result<AccountId, Error> {
         self.import_account_ufvk(ufvk, birthday_height, AccountPurpose::ViewOnly)
             .await
     }
@@ -177,7 +177,7 @@ where
         ufvk: &UnifiedFullViewingKey,
         birthday_height: Option<u32>,
         purpose: AccountPurpose,
-    ) -> Result<String, Error> {
+    ) -> Result<AccountId, Error> {
         tracing::info!("Importing account with Ufvk: {:?}", ufvk);
         let mut client = self.client.clone();
         let birthday = match birthday_height {
@@ -205,13 +205,12 @@ where
             AccountBirthday::from_treestate(treestate, None).map_err(|_| Error::BirthdayError)?
         };
 
-        let _account = self
+        Ok(self
             .db
             .write()
             .await
-            .import_account_ufvk(ufvk, &birthday, purpose)?;
-
-        Ok("0".to_string())
+            .import_account_ufvk(ufvk, &birthday, purpose)?
+            .id())
     }
 
     pub async fn suggest_scan_ranges(&self) -> Result<Vec<BlockRange>, Error> {
@@ -384,12 +383,10 @@ where
     ///
     async fn propose_transfer(
         &self,
-        account_index: usize,
+        account_id: AccountId,
         to_address: ZcashAddress,
         value: u64,
     ) -> Result<Proposal<FeeRule, NoteRef>, Error> {
-        let account_id = self.db.read().await.get_account_ids()?[account_index];
-
         let input_selector = GreedyInputSelector::new(
             SingleOutputChangeStrategy::new(FeeRule::standard(), None, ShieldedProtocol::Orchard),
             Default::default(),
@@ -467,14 +464,14 @@ where
     pub async fn transfer(
         &self,
         seed_phrase: &str,
-        from_account_index: usize,
+        from_account_id: AccountId,
         to_address: ZcashAddress,
         value: u64,
     ) -> Result<(), Error> {
         let mut client = self.client.clone();
         let usk = usk_from_seed_str(seed_phrase, 0, &self.network)?;
         let proposal = self
-            .propose_transfer(from_account_index, to_address, value)
+            .propose_transfer(from_account_id, to_address, value)
             .await?;
         // TODO: Add callback for approving the transaction here
         let txids = self.create_proposed_transactions(proposal, &usk).await?;
@@ -512,7 +509,7 @@ where
 
 fn usk_from_seed_str(
     seed: &str,
-    account_index: u32,
+    account_id: u32,
     network: &consensus::Network,
 ) -> Result<UnifiedSpendingKey, Error> {
     let mnemonic = <Mnemonic<English>>::from_phrase(seed).map_err(|_| Error::InvalidSeedPhrase)?;
@@ -522,7 +519,6 @@ fn usk_from_seed_str(
         seed.zeroize();
         SecretVec::new(secret)
     };
-    let usk =
-        UnifiedSpendingKey::from_seed(network, seed.expose_secret(), account_index.try_into()?)?;
+    let usk = UnifiedSpendingKey::from_seed(network, seed.expose_secret(), account_id.try_into()?)?;
     Ok(usk)
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Remove account_index from wallet.rs and bindgen/wallet.rs
- Uses AccoutId globally for referring to accounts
- update demo-wallet to reflect new API

## Issues

- Closes #29 