### PR TITLE
Updated transaction proposal and approval flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.5.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "bech32",
  "bs58",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "async-trait",
  "base64",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_memory"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "async-trait",
  "bs58",
@@ -3748,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.11.2"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "bs58",
  "byteorder",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3793,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "bech32",
  "bip32",
@@ -3834,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "aes",
  "bip32",
@@ -3873,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3893,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "document-features",
  "memuse",
@@ -3964,7 +3964,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=9673cc2859e8a2528d1efd3c74795363f87ddf8f#9673cc2859e8a2528d1efd3c74795363f87ddf8f"
 dependencies = [
  "base64",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -858,7 +858,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1680,6 +1680,9 @@ name = "nonempty"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -3648,11 +3651,13 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.5.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "bech32",
  "bs58",
  "f4jumble",
+ "serde",
+ "serde_with",
  "zcash_encoding",
  "zcash_protocol",
 ]
@@ -3660,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.13.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "async-trait",
  "base64",
@@ -3686,6 +3691,8 @@ dependencies = [
  "rayon",
  "sapling-crypto",
  "secrecy",
+ "serde",
+ "serde_with",
  "shardtree",
  "subtle",
  "time",
@@ -3706,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_memory"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "async-trait",
  "bs58",
@@ -3741,7 +3748,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.11.2"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "bs58",
  "byteorder",
@@ -3777,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.1"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -3786,7 +3793,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "bech32",
  "bip32",
@@ -3827,7 +3834,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "aes",
  "bip32",
@@ -3851,6 +3858,7 @@ dependencies = [
  "ripemd",
  "sapling-crypto",
  "secp256k1",
+ "serde",
  "sha2",
  "subtle",
  "tracing",
@@ -3865,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.17.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -3885,10 +3893,12 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.3.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "document-features",
  "memuse",
+ "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -3954,11 +3964,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.1.0"
-source = "git+https://github.com/ChainSafe/librustzcash?rev=d1fa3e846c5e61de3f1df23dd9f4d5416915631a#d1fa3e846c5e61de3f1df23dd9f4d5416915631a"
+source = "git+https://github.com/ChainSafe/librustzcash?rev=efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0#efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0"
 dependencies = [
  "base64",
  "nom",
  "percent-encoding",
+ "serde",
+ "serde_with",
  "zcash_address",
  "zcash_protocol",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ tokio_with_wasm = { version = "0.7.1", features = ["rt", "rt-multi-thread", "syn
 
 ## Zcash dependencies
 
-zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
-zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
-zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", features = ["orchard"] }
-zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a" }
-zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a" }
-zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["bundled-prover"] }
+zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
+zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
+zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", features = ["orchard"] }
+zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0" }
+zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0" }
+zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["bundled-prover"] }
 
 ## gRPC Web dependencies
 prost = { version = "0.12", default-features = false }
@@ -77,7 +77,7 @@ tonic = { version = "0.12", default-features = false, features = [
 
 # Used in Native tests
 tokio = { version = "1.0" }
-zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "d1fa3e846c5e61de3f1df23dd9f4d5416915631a", default-features = false, features = ["unstable", "orchard"], optional = true }
+zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["unstable", "orchard"], optional = true }
 
 getrandom = { version = "0.2", features = ["js"] }
 thiserror = "1.0.63"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,12 +61,12 @@ tokio_with_wasm = { version = "0.7.1", features = ["rt", "rt-multi-thread", "syn
 
 ## Zcash dependencies
 
-zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
-zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
-zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", features = ["orchard"] }
-zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0" }
-zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0" }
-zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["bundled-prover"] }
+zcash_keys = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f", features = ["transparent-inputs", "orchard", "sapling", "unstable"] }
+zcash_client_backend = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f", default-features = false, features = ["sync", "lightwalletd-tonic", "wasm-bindgen", "orchard"] }
+zcash_client_memory = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f", features = ["orchard"] }
+zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f" }
+zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f" }
+zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f", default-features = false, features = ["bundled-prover"] }
 
 ## gRPC Web dependencies
 prost = { version = "0.12", default-features = false }
@@ -77,7 +77,7 @@ tonic = { version = "0.12", default-features = false, features = [
 
 # Used in Native tests
 tokio = { version = "1.0" }
-zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "efbaeec65dbf3b5126454fcb7a8f9be83cb9a9e0", default-features = false, features = ["unstable", "orchard"], optional = true }
+zcash_client_sqlite = { git = "https://github.com/ChainSafe/librustzcash", rev = "9673cc2859e8a2528d1efd3c74795363f87ddf8f", default-features = false, features = ["unstable", "orchard"], optional = true }
 
 getrandom = { version = "0.2", features = ["js"] }
 thiserror = "1.0.63"

--- a/packages/demo-wallet/src/App/Actions.tsx
+++ b/packages/demo-wallet/src/App/Actions.tsx
@@ -61,6 +61,12 @@ export async function triggerTransfer(
     }
 
     let activeAccountSeedPhrase = state.accountSeeds.get(state.activeAccount) || "";
-    await state.webWallet?.transfer(activeAccountSeedPhrase, state.activeAccount, toAddress, amount);
-    await syncStateWithWallet(state, dispatch);
+    
+    let proposal = await state.webWallet?.propose_transfer(state.activeAccount, toAddress, amount);
+    console.log(JSON.stringify(proposal.describe(), null, 2));
+    
+    let txids = await state.webWallet.create_proposed_transactions(proposal, activeAccountSeedPhrase);
+    console.log(JSON.stringify(txids, null, 2));
+    
+    await state.webWallet.send_authorized_transactions(txids);
 }

--- a/packages/demo-wallet/src/App/components/ImportAccount.tsx
+++ b/packages/demo-wallet/src/App/components/ImportAccount.tsx
@@ -18,6 +18,7 @@ export function ImportAccount() {
     await addNewAccount(state, dispatch, seedPhrase, birthdayHeight);
     toast.success("Account imported successfully", {
       position: "top-center",
+      autoClose: 2000,
     });
     setBirthdayHeight(0);
     setSeedPhrase("");

--- a/src/bindgen/mod.rs
+++ b/src/bindgen/mod.rs
@@ -1,1 +1,2 @@
+pub mod proposal;
 pub mod wallet;

--- a/src/bindgen/proposal.rs
+++ b/src/bindgen/proposal.rs
@@ -5,7 +5,7 @@ use zcash_primitives::transaction::fees::zip317::FeeRule;
 
 /// A handler to an immutable proposal. This can be passed to `create_proposed_transactions` to prove/authorize the transactions
 /// before they are sent to the network.
-/// 
+///
 /// The proposal can be reviewed by calling `describe` which will return a JSON object with the details of the proposal.
 #[wasm_bindgen]
 pub struct Proposal {

--- a/src/bindgen/proposal.rs
+++ b/src/bindgen/proposal.rs
@@ -1,0 +1,32 @@
+use wasm_bindgen::prelude::*;
+
+use super::wallet::NoteRef;
+use zcash_primitives::transaction::fees::zip317::FeeRule;
+
+/// A handler to an immutable proposal. This can be passed to `create_proposed_transactions` to prove/authorize the transactions
+/// before they are sent to the network.
+/// 
+/// The proposal can be reviewed by calling `describe` which will return a JSON object with the details of the proposal.
+#[wasm_bindgen]
+pub struct Proposal {
+    inner: zcash_client_backend::proposal::Proposal<FeeRule, NoteRef>,
+}
+
+impl From<zcash_client_backend::proposal::Proposal<FeeRule, NoteRef>> for Proposal {
+    fn from(inner: zcash_client_backend::proposal::Proposal<FeeRule, NoteRef>) -> Self {
+        Self { inner }
+    }
+}
+
+impl From<Proposal> for zcash_client_backend::proposal::Proposal<FeeRule, NoteRef> {
+    fn from(proposal: Proposal) -> Self {
+        proposal.inner
+    }
+}
+
+#[wasm_bindgen]
+impl Proposal {
+    pub fn describe(&self) -> JsValue {
+        serde_wasm_bindgen::to_value(&self.inner).unwrap()
+    }
+}

--- a/src/bindgen/wallet.rs
+++ b/src/bindgen/wallet.rs
@@ -1,25 +1,24 @@
 use std::num::NonZeroU32;
 
+use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use tonic_web_wasm_client::Client;
 
 use crate::error::Error;
-use crate::{BlockRange, Wallet, PRUNING_DEPTH};
+use crate::wallet::usk_from_seed_str;
+use crate::{bindgen::proposal::Proposal, BlockRange, Wallet, PRUNING_DEPTH};
 use wasm_thread as thread;
 use zcash_address::ZcashAddress;
-use zcash_client_backend::data_api::{WalletRead, InputSource};
-use zcash_client_backend::proposal::Proposal;
+use zcash_client_backend::data_api::{InputSource, WalletRead};
 use zcash_client_backend::proto::service::{
     compact_tx_streamer_client::CompactTxStreamerClient, ChainSpec,
 };
 use zcash_client_memory::MemoryWalletDb;
 use zcash_keys::keys::UnifiedFullViewingKey;
 use zcash_primitives::consensus::{self, BlockHeight};
-use zcash_primitives::transaction::fees::zip317::FeeRule;
 use zcash_primitives::transaction::TxId;
-
 
 pub type MemoryWallet<T> = Wallet<MemoryWalletDb<consensus::Network>, T>;
 pub type AccountId =
@@ -173,32 +172,6 @@ impl WebWallet {
     }
 
     ///
-    /// Create a transaction proposal to send funds from the wallet to a given address and if approved will sign it and send the proposed transaction(s) to the network
-    ///
-    /// First a proposal is created by selecting inputs and outputs to cover the requested amount. This proposal is then sent to the approval callback.
-    /// This allows wallet developers to display a confirmation dialog to the user before continuing.
-    ///
-    /// # Arguments
-    ///
-    pub async fn transfer(
-        &self,
-        seed_phrase: &str,
-        from_account_id: u32,
-        to_address: String,
-        value: u64,
-    ) -> Result<(), Error> {
-        let to_address = ZcashAddress::try_from_encoded(&to_address)?;
-        self.inner
-            .transfer(
-                seed_phrase,
-                AccountId::from(from_account_id),
-                to_address,
-                value,
-            )
-            .await
-    }
-
-    ///
     /// Create a transaction proposal to send funds from the wallet to a given address.
     ///
     pub async fn propose_transfer(
@@ -206,37 +179,43 @@ impl WebWallet {
         account_id: u32,
         to_address: String,
         value: u64,
-    ) -> Result<JsValue, Error> {
+    ) -> Result<Proposal, Error> {
         let to_address = ZcashAddress::try_from_encoded(&to_address)?;
-        let proposal = self.inner.propose_transfer(AccountId::from(account_id), to_address, value).await?;
-        Ok(serde_wasm_bindgen::to_value(&proposal).unwrap())
+        let proposal = self
+            .inner
+            .propose_transfer(AccountId::from(account_id), to_address, value)
+            .await?;
+        Ok(proposal.into())
     }
-    
-    ///
-    /// Perform the proving and signing required to create one or more transaction from the proposal. Created transactions are stored in the wallet database.
-    ///
-    /// Note: At the moment this requires a USK but ideally we want to be able to hand the signing off to a separate service
-    ///     e.g. browser plugin, hardware wallet, etc. Will need to look into refactoring librustzcash create_proposed_transactions to allow for this
-    ///
-    // pub async fn create_proposed_transactions(
-    //     &self,
-    //     proposal: Proposal<FeeRule, NoteRef>,
-    //     usk: &UnifiedSpendingKey,
-    // ) -> Result<Vec<TxId>, Error> {
-    //     self.inner
-    //         .create_proposed_transactions(proposal, usk)
-    //         .await
-    // }
 
-    /// 
+    ///
+    /// Perform the proving and signing required to create one or more transaction from the proposal.
+    /// Created transactions are stored in the wallet database and a list of the IDs is returned
+    ///
+    pub async fn create_proposed_transactions(
+        &self,
+        proposal: Proposal,
+        seed_phrase: &str,
+    ) -> Result<JsValue, Error> {
+        let usk = usk_from_seed_str(seed_phrase, 0, &self.inner.network)?;
+        let txids = self
+            .inner
+            .create_proposed_transactions(proposal.into(), &usk)
+            .await?;
+        Ok(serde_wasm_bindgen::to_value(&txids).unwrap())
+    }
+
+    ///
     /// Send a list of transactions to the network via the lightwalletd instance this wallet is connected to
-    /// 
-    // pub async fn send_authorized_transactions(
-    //     &self,
-    //     txids: &[TxId],
-    // ) -> Result<(), Error> {
-    //     self.inner.send_authorized_transactions(txids).await
-    // }
+    ///
+    pub async fn send_authorized_transactions(&self, txids: JsValue) -> Result<(), Error> {
+        let txids: NonEmpty<TxId> = serde_wasm_bindgen::from_value(txids).unwrap();
+        self.inner.send_authorized_transactions(&txids).await
+    }
+
+    ///////////////////////////////////////////////////////////////////////////////////////
+    // lightwalletd gRPC methods
+    ///////////////////////////////////////////////////////////////////////////////////////
 
     /// Forwards a call to lightwalletd to retrieve the height of the latest block in the chain
     pub async fn get_latest_block(&self) -> Result<u64, Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,8 @@ pub enum Error {
     SqliteError(#[from] zcash_client_sqlite::error::SqliteClientError),
     #[error("Invalid seed phrase")]
     InvalidSeedPhrase,
+    #[error("Failed when creating transaction")]
+    FailedToCreateTransaction,
 }
 
 impl From<Error> for JsValue {

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -453,10 +453,7 @@ where
         Ok(transactions)
     }
 
-    pub async fn send_authorized_transactions(
-        &self,
-        txids: &NonEmpty<TxId>,
-    ) -> Result<(), Error> {
+    pub async fn send_authorized_transactions(&self, txids: &NonEmpty<TxId>) -> Result<(), Error> {
         let mut client = self.client.clone();
         for txid in txids.iter() {
             let (txid, raw_tx) = self
@@ -508,7 +505,7 @@ where
     }
 }
 
-fn usk_from_seed_str(
+pub(crate) fn usk_from_seed_str(
     seed: &str,
     account_id: u32,
     network: &consensus::Network,


### PR DESCRIPTION
## Changes

- Adds a new Proposal struct with `#[wasm_bindgen]` allowing the js code to hold a handle to a proposal
- Removes `transfer` method in favour of a `propose`, `create_proposed`, `submit` flow which allows for the user to review and approve a proposal

This will also better support the AccountProvider model we are aiming for

## Issues

<!--

Please link any issues that this pull request is related to and use the GitHub
supported format for automatically closing issues (ie, closes #123, fixes #123)

-->
- Closes #32 