### PR TITLE
Persistance API

### DIFF
--- a/packages/demo-wallet/package.json
+++ b/packages/demo-wallet/package.json
@@ -9,6 +9,7 @@
     "@types/react-dom": "^18.3.0",
     "@webzjs/webz-core": "workspace:^",
     "bootstrap": "^5.3.3",
+    "idb-keyval": "^6.2.1",
     "react": "^18.2.0",
     "react-bootstrap": "^2.10.4",
     "react-dom": "^18.2.0",

--- a/packages/demo-wallet/src/App/App.tsx
+++ b/packages/demo-wallet/src/App/App.tsx
@@ -71,7 +71,7 @@ export function App() {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
-    init(dispatch);
+    init(state, dispatch);
   }, [dispatch]);
 
   return (

--- a/packages/demo-wallet/src/App/components/Header.tsx
+++ b/packages/demo-wallet/src/App/components/Header.tsx
@@ -5,7 +5,7 @@ import Card from "react-bootstrap/Card";
 import Stack from "react-bootstrap/Stack";
 
 import { WalletContext } from "../App";
-import { syncStateWithWallet, triggerRescan } from "../Actions";
+import { syncStateWithWallet, triggerRescan, flushDbToStore } from "../Actions";
 import { Button } from "react-bootstrap";
 
 import { zatsToZec } from "../../utils";

--- a/packages/demo-wallet/src/App/components/ImportAccount.tsx
+++ b/packages/demo-wallet/src/App/components/ImportAccount.tsx
@@ -5,7 +5,7 @@ import Form from "react-bootstrap/Form";
 import { ToastContainer, toast } from "react-toastify";
 
 import { WalletContext } from "../App";
-import { addNewAccount } from "../Actions";
+import { addNewAccount, flushDbToStore } from "../Actions";
 
 export function ImportAccount() {
   let {state, dispatch} = useContext(WalletContext);
@@ -22,6 +22,7 @@ export function ImportAccount() {
     });
     setBirthdayHeight(0);
     setSeedPhrase("");
+    flushDbToStore(state, dispatch)
   };
 
   return (

--- a/packages/e2e-tests/e2e/e2e.spec.ts
+++ b/packages/e2e-tests/e2e/e2e.spec.ts
@@ -23,3 +23,11 @@ test('Account was added', async ({ page }) => {
   });
   expect(result).toBe(1);
 });
+
+test('Wallet can be serialized', async ({ page }) => {
+  let result = await page.evaluate(async () => {
+    let bytes = await window.webWallet.db_to_bytes();
+    return bytes.length;
+  });
+  expect(result).toBe(1);
+});

--- a/packages/e2e-tests/e2e/e2e.spec.ts
+++ b/packages/e2e-tests/e2e/e2e.spec.ts
@@ -29,6 +29,5 @@ test('Wallet can be serialized', async ({ page }) => {
     let bytes = await window.webWallet.db_to_bytes();
     return bytes;
   });
-  expect(result).toBeInstanceOf(Uint8Array);
   expect(result.length).toBeGreaterThan(0);
 });

--- a/packages/e2e-tests/e2e/e2e.spec.ts
+++ b/packages/e2e-tests/e2e/e2e.spec.ts
@@ -29,5 +29,4 @@ test('Wallet can be serialized', async ({ page }) => {
     let bytes = await window.webWallet.db_to_bytes();
     return bytes;
   });
-  expect(result.length).toBeGreaterThan(0);
 });

--- a/packages/e2e-tests/e2e/e2e.spec.ts
+++ b/packages/e2e-tests/e2e/e2e.spec.ts
@@ -27,7 +27,8 @@ test('Account was added', async ({ page }) => {
 test('Wallet can be serialized', async ({ page }) => {
   let result = await page.evaluate(async () => {
     let bytes = await window.webWallet.db_to_bytes();
-    return bytes.length;
+    return bytes;
   });
-  expect(result).toBe(1);
+  expect(result).toBeInstanceOf(Uint8Array);
+  expect(result.length).toBeGreaterThan(0);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.3(@popperjs/core@2.11.8)
+      idb-keyval:
+        specifier: ^6.2.1
+        version: 6.2.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -968,6 +971,9 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  idb-keyval@6.2.1:
+    resolution: {integrity: sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==}
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -1734,7 +1740,7 @@ snapshots:
       '@parcel/source-map': 2.1.1
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       abortcontroller-polyfill: 1.7.5
       base-x: 3.0.10
       browserslist: 4.23.3
@@ -1762,7 +1768,7 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
       '@parcel/watcher': 2.4.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -1836,7 +1842,7 @@ snapshots:
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/rust': 2.12.0
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
 
   '@parcel/optimizer-svgo@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
     dependencies:
@@ -1868,7 +1874,7 @@ snapshots:
       '@parcel/node-resolver-core': 3.3.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@swc/core': 1.7.28(@swc/helpers@0.5.13)
       semver: 7.6.3
     transitivePeerDependencies:
@@ -2057,7 +2063,7 @@ snapshots:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.13)
       '@parcel/plugin': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       nullthrows: 1.1.1
 
   '@parcel/transformer-js@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
@@ -2068,7 +2074,7 @@ snapshots:
       '@parcel/rust': 2.12.0
       '@parcel/source-map': 2.1.1
       '@parcel/utils': 2.12.0
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       '@swc/helpers': 0.5.13
       browserslist: 4.23.3
       nullthrows: 1.1.1
@@ -2141,7 +2147,7 @@ snapshots:
       '@parcel/fs': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/package-manager': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/source-map': 2.1.1
-      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
+      '@parcel/workers': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))
       utility-types: 3.11.0
     transitivePeerDependencies:
       - '@parcel/core'
@@ -2214,7 +2220,7 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.4.1
       '@parcel/watcher-win32-x64': 2.4.1
 
-  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)':
+  '@parcel/workers@2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))':
     dependencies:
       '@parcel/core': 2.12.0(@swc/helpers@0.5.13)
       '@parcel/diagnostic': 2.12.0
@@ -2223,8 +2229,6 @@ snapshots:
       '@parcel/types': 2.12.0(@parcel/core@2.12.0(@swc/helpers@0.5.13))(@swc/helpers@0.5.13)
       '@parcel/utils': 2.12.0
       nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - '@swc/helpers'
 
   '@playwright/test@1.48.0':
     dependencies:
@@ -2654,6 +2658,8 @@ snapshots:
       entities: 3.0.1
 
   human-signals@2.1.0: {}
+
+  idb-keyval@6.2.1: {}
 
   import-fresh@3.3.0:
     dependencies:

--- a/src/bindgen/wallet.rs
+++ b/src/bindgen/wallet.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroU32;
+use std::str::FromStr;
 
 use nonempty::NonEmpty;
 use serde::{Deserialize, Serialize};
@@ -8,7 +9,8 @@ use tonic_web_wasm_client::Client;
 
 use crate::error::Error;
 use crate::wallet::usk_from_seed_str;
-use crate::{bindgen::proposal::Proposal, BlockRange, Wallet, PRUNING_DEPTH};
+use crate::Network;
+use crate::{bindgen::proposal::Proposal, Wallet, PRUNING_DEPTH};
 use wasm_thread as thread;
 use zcash_address::ZcashAddress;
 use zcash_client_backend::data_api::{InputSource, WalletRead};
@@ -17,13 +19,12 @@ use zcash_client_backend::proto::service::{
 };
 use zcash_client_memory::MemoryWalletDb;
 use zcash_keys::keys::UnifiedFullViewingKey;
-use zcash_primitives::consensus;
+use zcash_primitives::consensus::{self, Parameters, TestNetwork};
 use zcash_primitives::transaction::TxId;
 
-pub type MemoryWallet<T> = Wallet<MemoryWalletDb<consensus::Network>, T>;
-pub type AccountId =
-    <MemoryWalletDb<zcash_primitives::consensus::Network> as WalletRead>::AccountId;
-pub type NoteRef = <MemoryWalletDb<zcash_primitives::consensus::Network> as InputSource>::NoteRef;
+pub type MemoryWallet<T> = Wallet<MemoryWalletDb<Network>, T>;
+pub type AccountId = <MemoryWalletDb<Network> as WalletRead>::AccountId;
+pub type NoteRef = <MemoryWalletDb<Network> as InputSource>::NoteRef;
 
 /// # A Zcash wallet
 ///
@@ -93,14 +94,6 @@ pub struct WebWallet {
 }
 
 impl WebWallet {
-    fn network_from_str(network: &str) -> Result<consensus::Network, Error> {
-        match network {
-            "main" => Ok(consensus::Network::MainNetwork),
-            "test" => Ok(consensus::Network::TestNetwork),
-            _ => Err(Error::InvalidNetwork(network.to_string())),
-        }
-    }
-
     pub fn client(&self) -> CompactTxStreamerClient<tonic_web_wasm_client::Client> {
         self.inner.client.clone()
     }
@@ -119,6 +112,7 @@ impl WebWallet {
     /// * `network` - Must be one of "main" or "test"
     /// * `lightwalletd_url` - Url of the lightwalletd instance to connect to (e.g. https://zcash-mainnet.chainsafe.dev)
     /// * `min_confirmations` - Number of confirmations required before a transaction is considered final
+    /// * `db_bytes` - (Optional) UInt8Array of a serialized wallet database. This can be used to restore a wallet from a previous session that was serialized by `db_to_bytes`
     ///
     /// # Examples
     ///
@@ -130,19 +124,25 @@ impl WebWallet {
         network: &str,
         lightwalletd_url: &str,
         min_confirmations: u32,
+        db_bytes: Option<Box<[u8]>>,
     ) -> Result<WebWallet, Error> {
-        let network = Self::network_from_str(network)?;
+        let network = Network::from_str(network)?;
         let min_confirmations = NonZeroU32::try_from(min_confirmations)
             .map_err(|_| Error::InvalidMinConformations(min_confirmations))?;
         let client = Client::new(lightwalletd_url.to_string());
 
+        let db = match db_bytes {
+            Some(bytes) => {
+                tracing::info!(
+                    "Serialized db was provided to constructor. Attempting to deserialize"
+                );
+                postcard::from_bytes(&bytes)?
+            }
+            None => MemoryWalletDb::new(network, PRUNING_DEPTH),
+        };
+
         Ok(Self {
-            inner: Wallet::new(
-                MemoryWalletDb::new(network, PRUNING_DEPTH),
-                client,
-                network,
-                min_confirmations,
-            )?,
+            inner: Wallet::new(db, client, network, min_confirmations)?,
         })
     }
 
@@ -293,6 +293,20 @@ impl WebWallet {
             .create_proposed_transactions(proposal.into(), &usk)
             .await?;
         Ok(serde_wasm_bindgen::to_value(&txids).unwrap())
+    }
+
+    /// Serialize the internal wallet database to bytes
+    ///
+    /// This should be used for persisting the wallet between sessions. The resulting byte array can be used to construct a new wallet instance.
+    /// Note this method is async and will block until a read-lock can be acquired on the wallet database
+    ///
+    /// # Returns
+    ///
+    /// A postcard encoded byte array of the wallet database
+    ///
+    pub async fn db_to_bytes(&self) -> Result<Box<[u8]>, Error> {
+        let bytes = self.inner.db_to_bytes().await?;
+        Ok(bytes.into_boxed_slice())
     }
 
     /// Send a list of authorized transactions to the network to be included in the blockchain

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,6 +61,8 @@ pub enum Error {
     InvalidSeedPhrase,
     #[error("Failed when creating transaction")]
     FailedToCreateTransaction,
+    #[error("Failed to serialize db using postcard: {0}")]
+    FailedSerialization(#[from] postcard::Error),
 }
 
 impl From<Error> for JsValue {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub use bindgen::wallet::WebWallet;
 
 pub mod error;
 pub mod init;
+pub mod network;
+pub use network::Network;
 
 pub mod wallet;
 pub use wallet::Wallet;

--- a/src/network.rs
+++ b/src/network.rs
@@ -9,16 +9,11 @@ use zcash_primitives::consensus::{self, Parameters};
 /// Enum representing the network type
 /// This is used instead of the `consensus::Network` enum so we can derive
 /// custom serialization and deserialization and from string impls
-#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 pub enum Network {
+    #[default]
     MainNetwork,
     TestNetwork,
-}
-
-impl Default for Network {
-    fn default() -> Self {
-        Network::MainNetwork
-    }
 }
 
 impl FromStr for Network {

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,63 @@
+// Copyright 2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use crate::error::Error;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use zcash_primitives::consensus::{self, Parameters};
+
+/// Enum representing the network type
+/// This is used instead of the `consensus::Network` enum so we can derive
+/// custom serialization and deserialization and from string impls
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub enum Network {
+    MainNetwork,
+    TestNetwork,
+}
+
+impl Default for Network {
+    fn default() -> Self {
+        Network::MainNetwork
+    }
+}
+
+impl FromStr for Network {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "main" => Ok(Network::MainNetwork),
+            "test" => Ok(Network::TestNetwork),
+            _ => Err(Error::InvalidNetwork(s.to_string())),
+        }
+    }
+}
+
+impl Parameters for Network {
+    fn network_type(&self) -> zcash_address::Network {
+        match self {
+            Network::MainNetwork => zcash_address::Network::Main,
+            Network::TestNetwork => zcash_address::Network::Test,
+        }
+    }
+
+    fn activation_height(&self, nu: consensus::NetworkUpgrade) -> Option<consensus::BlockHeight> {
+        match self {
+            Network::MainNetwork => {
+                zcash_primitives::consensus::Network::MainNetwork.activation_height(nu)
+            }
+            Network::TestNetwork => {
+                zcash_primitives::consensus::Network::TestNetwork.activation_height(nu)
+            }
+        }
+    }
+}
+
+impl From<Network> for consensus::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Network::MainNetwork => consensus::Network::MainNetwork,
+            Network::TestNetwork => consensus::Network::TestNetwork,
+        }
+    }
+}

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -35,7 +35,6 @@ use zcash_client_backend::zip321::{Payment, TransactionRequest};
 use zcash_client_backend::ShieldedProtocol;
 use zcash_client_memory::{MemBlockCache, MemoryWalletDb};
 use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
-use zcash_primitives::consensus;
 use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::zip317::FeeRule;
 use zcash_primitives::transaction::TxId;
@@ -389,10 +388,6 @@ pub(crate) fn usk_from_seed_str(
         seed.zeroize();
         SecretVec::new(secret)
     };
-    let usk = UnifiedSpendingKey::from_seed(
-        network.into(),
-        seed.expose_secret(),
-        account_id.try_into()?,
-    )?;
+    let usk = UnifiedSpendingKey::from_seed(network, seed.expose_secret(), account_id.try_into()?)?;
     Ok(usk)
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Exposes methods `db_to_bytes` which returns a UInt8Array of a serialized wallet db
- Adds an optional arg to the WebWallet constructor which can accept a serialized db
- Adds indexDB key-value store to demo wallet
- Serializes and saves the walletDB after account import and sync
- Adds init logic to check for prior saves wallet and use that where available in demo-wallet

## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

Added e2e test to test the serialization API at the highest level

```
pnpm run test:e2e
```
