### PR TITLE
WebZ expose Zcash key types

### DIFF
--- a/src/bindgen/keys.rs
+++ b/src/bindgen/keys.rs
@@ -1,0 +1,86 @@
+// Copyright 2024 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+use crate::{error::Error, Network};
+use zcash_primitives::{consensus, zip32::AccountId};
+
+/// A Zcash spending key
+///
+/// This is a wrapper around the `zcash_keys::keys::SpendingKey` type. It can be created from at least 32 bytes of seed entropy
+#[wasm_bindgen]
+pub struct UnifiedSpendingKey {
+    inner: zcash_keys::keys::UnifiedSpendingKey,
+}
+
+#[wasm_bindgen]
+impl UnifiedSpendingKey {
+    /// Construct a new UnifiedSpendingKey
+    ///
+    /// # Arguments
+    ///
+    /// * `network` - Must be either "main" or "test"
+    /// * `seed` - At least 32 bytes of entry. Care should be taken as to how this is derived
+    /// * `hd_index` - [ZIP32](https://zips.z.cash/zip-0032) hierarchical deterministic index of the account
+    ///
+    #[wasm_bindgen(constructor)]
+    pub fn new(network: &str, seed: Box<[u8]>, hd_index: u32) -> Result<UnifiedSpendingKey, Error> {
+        let network = Network::from_str(network)?;
+        Ok(Self {
+            inner: zcash_keys::keys::UnifiedSpendingKey::from_seed(
+                &network,
+                &seed,
+                AccountId::try_from(hd_index)?,
+            )?,
+        })
+    }
+
+    /// Obtain the UFVK corresponding to this spending key
+    pub fn to_unified_full_viewing_key(&self) -> UnifiedFullViewingKey {
+        UnifiedFullViewingKey {
+            inner: self.inner.to_unified_full_viewing_key(),
+        }
+    }
+}
+
+/// A Zcash viewing key
+///
+/// This is a wrapper around the `zcash_keys::keys::ViewingKey` type.
+/// UFVKs should be generated from a spending key by calling `to_unified_full_viewing_key`
+/// They can also be encoded and decoded to a canonical string representation
+#[wasm_bindgen]
+pub struct UnifiedFullViewingKey {
+    inner: zcash_keys::keys::UnifiedFullViewingKey,
+}
+
+#[wasm_bindgen]
+impl UnifiedFullViewingKey {
+    /// Encode the UFVK to a string
+    ///
+    /// # Arguments
+    ///
+    /// * `network` - Must be either "main" or "test"
+    ///
+    pub fn encode(&self, network: &str) -> Result<String, Error> {
+        let network = Network::from_str(network)?;
+        Ok(self.inner.encode(&network))
+    }
+
+    /// Construct a UFVK from its encoded string representation
+    ///
+    /// # Arguments
+    ///
+    /// * `network` - Must be either "main" or "test"
+    /// * `encoding` - The encoded string representation of the UFVK
+    ///
+    #[wasm_bindgen(constructor)]
+    pub fn new(network: &str, encoding: &str) -> Result<UnifiedFullViewingKey, Error> {
+        let network = Network::from_str(network)?;
+        Ok(Self {
+            inner: zcash_keys::keys::UnifiedFullViewingKey::decode(&network, s)
+                .map_err(|e| Error::KeyDecodingError(e))?,
+        })
+    }
+}

--- a/src/bindgen/keys.rs
+++ b/src/bindgen/keys.rs
@@ -79,7 +79,7 @@ impl UnifiedFullViewingKey {
     pub fn new(network: &str, encoding: &str) -> Result<UnifiedFullViewingKey, Error> {
         let network = Network::from_str(network)?;
         Ok(Self {
-            inner: zcash_keys::keys::UnifiedFullViewingKey::decode(&network, s)
+            inner: zcash_keys::keys::UnifiedFullViewingKey::decode(&network, encoding)
                 .map_err(|e| Error::KeyDecodingError(e))?,
         })
     }

--- a/src/bindgen/mod.rs
+++ b/src/bindgen/mod.rs
@@ -1,2 +1,3 @@
+pub mod keys;
 pub mod proposal;
 pub mod wallet;

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,8 @@ pub enum Error {
     AddressGenerationError(#[from] zcash_keys::keys::AddressGenerationError),
     #[error("Error attempting to decode address: {0}")]
     AddressDecodingError(#[from] zcash_address::ParseError),
+    #[error("Error attempting to decode key: {0}")]
+    KeyDecodingError(String),
     #[error("Invalid network string given: {0}")]
     InvalidNetwork(String),
     #[error("Error returned from GRPC server: {0}")]


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

- Adds a new `keys` module to webzjs
- Exposes UnifiedSpendingKey and UnifiedFullViewingKey types with conversions and encoding where appropriate
