### PR TITLE
fix: useMetamask dependency loop fix

### DIFF
--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/MetaMask/template-snap-monorepo.git"
   },
   "source": {
-    "shasum": "SA1fH7ay1ietGUsIELeD6rgpMuXu/rusR65jSdjCBrk=",
+    "shasum": "H66kPf5KzVuH2Wh122uNoA/nMaSXORtaHfgw8z8u71o=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/web-wallet/src/hooks/snaps/useMetaMask.ts
+++ b/packages/web-wallet/src/hooks/snaps/useMetaMask.ts
@@ -49,7 +49,7 @@ export const useMetaMask = () => {
     };
 
     detect().catch(console.error);
-  }, [detectFlask, getSnap, provider]);
+  }, [provider]);
 
   return { isFlask, snapsDetected, installedSnap, getSnap };
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -17418,17 +17418,17 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A^5.6.2#optional!builtin<compat/typescript>":
   version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
+  checksum: 10c0/ac8307bb06bbfd08ae7137da740769b7d8c3ee5943188743bb622c621f8ad61d244767480f90fbd840277fbf152d8932aa20c33f867dea1bb5e79b187ca1a92f
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=cef18b"
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=379a07"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
Fixed bug causing infinite loop, useEffect-s dependency array issue,
`snap_manageState` and `wallet_getSnaps` RPC were triggering constantly.