### PR TITLE
fix: useMetamask dependency loop bug

### DIFF
--- a/packages/web-wallet/src/hooks/snaps/useMetaMask.ts
+++ b/packages/web-wallet/src/hooks/snaps/useMetaMask.ts
@@ -49,7 +49,7 @@ export const useMetaMask = () => {
     };
 
     detect().catch(console.error);
-  }, [detectFlask, getSnap, provider]);
+  }, [provider]);
 
   return { isFlask, snapsDetected, installedSnap, getSnap };
 };


### PR DESCRIPTION
Fixed bug causing infinite loop, useEffect-s dependency array issue,
`snap_manageState` and `wallet_getSnaps` RPC were triggering constantly.