### PR TITLE
Propose shield fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3316,6 +3316,7 @@ dependencies = [
  "wasm-bindgen",
  "zcash_address",
  "zcash_primitives",
+ "zcash_protocol",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,6 +3402,7 @@ dependencies = [
  "zcash_primitives",
  "zcash_proofs",
  "zcash_protocol",
+ "zip32",
  "zip321",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3349,6 +3349,7 @@ dependencies = [
  "wasm-bindgen",
  "zcash_address",
  "zcash_primitives",
+ "zcash_protocol",
  "zip321",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ zcash_primitives = { git = "https://github.com/ChainSafe/librustzcash", rev = "4
 zcash_address = { git = "https://github.com/ChainSafe/librustzcash", rev = "46e8ee0937b61fdbb417df7c663f62e6945d8090" }
 zcash_proofs = { git = "https://github.com/ChainSafe/librustzcash", rev = "46e8ee0937b61fdbb417df7c663f62e6945d8090", default-features = false, features = ["bundled-prover", "multicore"] }
 zip321 = { git = "https://github.com/ChainSafe/librustzcash", rev = "46e8ee0937b61fdbb417df7c663f62e6945d8090" }
+zip32 = { version = "0.1.3" }
 zcash_protocol = { git = "https://github.com/ChainSafe/librustzcash", rev = "46e8ee0937b61fdbb417df7c663f62e6945d8090", default-features = false }
 pczt = { git = "https://github.com/ChainSafe/librustzcash", rev = "46e8ee0937b61fdbb417df7c663f62e6945d8090", default-features = false, features = ["orchard", "sapling", "transparent"] }
 sapling = { package = "sapling-crypto", version = "0.4", default-features = false }

--- a/crates/webzjs-common/Cargo.toml
+++ b/crates/webzjs-common/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 serde.workspace = true
 zcash_primitives.workspace = true
 zcash_address.workspace = true
+zcash_protocol.workspace = true
 thiserror.workspace = true
 wasm-bindgen.workspace = true
 js-sys.workspace = true

--- a/crates/webzjs-common/src/network.rs
+++ b/crates/webzjs-common/src/network.rs
@@ -4,7 +4,7 @@
 use crate::error::Error;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-use zcash_primitives::consensus::{self, Parameters};
+use zcash_protocol::consensus::{self, Parameters};
 
 /// Enum representing the network type
 /// This is used instead of the `consensus::Network` enum so we can derive
@@ -29,10 +29,10 @@ impl FromStr for Network {
 }
 
 impl Parameters for Network {
-    fn network_type(&self) -> zcash_address::Network {
+    fn network_type(&self) -> zcash_protocol::consensus::NetworkType {
         match self {
-            Network::MainNetwork => zcash_address::Network::Main,
-            Network::TestNetwork => zcash_address::Network::Test,
+            Network::MainNetwork => zcash_protocol::consensus::NetworkType::Main,
+            Network::TestNetwork => zcash_protocol::consensus::NetworkType::Test,
         }
     }
 

--- a/crates/webzjs-keys/src/pczt_sign.rs
+++ b/crates/webzjs-keys/src/pczt_sign.rs
@@ -131,7 +131,7 @@ pub async fn pczt_sign_inner(
         .finish();
     let mut signer = Signer::new(pczt).unwrap();
     //.map_err(|e| anyhow!("Failed to initialize Signer: {:?}", e))?;
-    for (account_index, spends) in keys {
+    for (_, spends) in keys {
         // let usk = UnifiedSpendingKey::from_seed(&params, seed, account_index)?;
         for keyref in spends {
             match keyref {

--- a/crates/webzjs-requests/Cargo.toml
+++ b/crates/webzjs-requests/Cargo.toml
@@ -16,7 +16,7 @@ wasm-opt = ["-O4", "-O4"]
 [dependencies]
 wasm-bindgen.workspace = true
 js-sys.workspace = true
-
+zcash_protocol.workspace = true
 zcash_address.workspace = true
 zcash_primitives.workspace = true
 zip321.workspace = true

--- a/crates/webzjs-requests/src/error.rs
+++ b/crates/webzjs-requests/src/error.rs
@@ -3,7 +3,7 @@ use wasm_bindgen::JsValue;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Error parsing zatoshi amount: {0}")]
-    InvalidAmount(#[from] zcash_primitives::transaction::components::amount::BalanceError),
+    InvalidAmount(#[from] zcash_protocol::value::BalanceError),
     #[error("Attempted to create a transaction with a memo to an unsupported recipient. Only shielded addresses are supported.")]
     UnsupportedMemoRecipient,
     #[error("Error constructing ZIP321 transaction request: {0}")]

--- a/crates/webzjs-wallet/Cargo.toml
+++ b/crates/webzjs-wallet/Cargo.toml
@@ -54,6 +54,7 @@ zcash_address = { workspace = true }
 zcash_protocol = { workspace = true, default-features = false }
 zcash_proofs = { workspace = true, default-features = false, features = ["bundled-prover", "multicore"] }
 zip321 = { workspace = true }
+zip32 = { workspace = true }
 pczt = { workspace = true, default-features = false, features = ["orchard", "sapling", "transparent"] }
 orchard = { version = "0.10.1", default-features = false }
 sapling = { workspace = true }

--- a/crates/webzjs-wallet/src/wallet.rs
+++ b/crates/webzjs-wallet/src/wallet.rs
@@ -323,7 +323,7 @@ where
         );
         let request = TransactionRequest::new(vec![Payment::without_memo(
             to_address,
-            NonNegativeAmount::from_u64(value)?,
+            Zatoshis::from_u64(value)?
         )])?;
 
         tracing::info!("Chain height: {:?}", self.db.read().await.chain_height()?);
@@ -519,7 +519,7 @@ where
         let input_selector = GreedyInputSelector::new();
         let request = TransactionRequest::new(vec![Payment::without_memo(
             to_address,
-            NonNegativeAmount::from_u64(value)?,
+            Zatoshis::from_u64(value)?
         )])?;
         let mut db = self.db.write().await;
         let proposal = propose_transfer::<_, _, _,_, <W as WalletCommitmentTrees>::Error>(
@@ -583,7 +583,7 @@ where
                         .collect::<Vec<_>>();
 
                     // Assume all non-dummy spent notes are from the same account.
-                    for (index, derivation) in non_dummy_spends {
+                    for (index, _) in non_dummy_spends {
                         updater.update_spend_with(index, |mut spend_updater| {
                             spend_updater.set_proof_generation_key(sapling_proof_gen_key.clone())
                         })?;

--- a/crates/webzjs-wallet/src/wallet.rs
+++ b/crates/webzjs-wallet/src/wallet.rs
@@ -47,10 +47,9 @@ use zcash_client_backend::proto::service::{
 };
 use zcash_client_backend::wallet::OvkPolicy;
 use zcash_client_backend::zip321::{Payment, TransactionRequest};
-use zcash_client_backend::ShieldedProtocol;
+use zcash_protocol::ShieldedProtocol;
 use zcash_client_memory::{MemBlockCache, MemoryWalletDb};
 use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 use zcash_primitives::transaction::fees::FeeRule;
 use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;

--- a/crates/webzjs-wallet/src/wallet.rs
+++ b/crates/webzjs-wallet/src/wallet.rs
@@ -43,27 +43,25 @@ use zcash_client_backend::proto::service::{
 };
 use zcash_client_backend::wallet::OvkPolicy;
 use zcash_client_backend::zip321::{Payment, TransactionRequest};
-use zcash_protocol::ShieldedProtocol;
 use zcash_client_memory::{MemBlockCache, MemoryWalletDb};
 use zcash_keys::keys::{UnifiedFullViewingKey, UnifiedSpendingKey};
 use zcash_primitives::transaction::fees::FeeRule;
 use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;
-
+use zcash_protocol::ShieldedProtocol;
 
 use zcash_client_backend::sync::run;
 
-use zip32;
-use zip32::fingerprint::SeedFingerprint;
 use zcash_protocol::consensus::Parameters;
 use zcash_protocol::value::Zatoshis;
+use zip32;
+use zip32::fingerprint::SeedFingerprint;
 
 const BATCH_SIZE: u32 = 10000;
 
 /// constant that signals what's the minimum transparent balance for proposing a
 /// shielding transaction
 const SHIELDING_THRESHOLD: Zatoshis = Zatoshis::const_from_u64(100000);
-
 
 /// # A Zcash wallet
 ///
@@ -323,7 +321,7 @@ where
         );
         let request = TransactionRequest::new(vec![Payment::without_memo(
             to_address,
-            Zatoshis::from_u64(value)?
+            Zatoshis::from_u64(value)?,
         )])?;
 
         tracing::info!("Chain height: {:?}", self.db.read().await.chain_height()?);
@@ -519,7 +517,7 @@ where
         let input_selector = GreedyInputSelector::new();
         let request = TransactionRequest::new(vec![Payment::without_memo(
             to_address,
-            Zatoshis::from_u64(value)?
+            Zatoshis::from_u64(value)?,
         )])?;
         let mut db = self.db.write().await;
         let proposal = propose_transfer::<_, _, _,_, <W as WalletCommitmentTrees>::Error>(

--- a/crates/webzjs-wallet/src/wallet.rs
+++ b/crates/webzjs-wallet/src/wallet.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-use std::convert::Infallible;
 use std::num::{NonZeroU32, NonZeroUsize};
 
 use bip0039::{English, Mnemonic};
@@ -16,13 +14,12 @@ use webzjs_common::Network;
 
 use pczt::roles::combiner::Combiner;
 use pczt::roles::prover::Prover;
-use pczt::roles::signer::Signer;
+
 use pczt::roles::updater::Updater;
-use pczt::roles::verifier::Verifier;
 use pczt::Pczt;
 use sapling::ProofGenerationKey;
 use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::Serialize;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -39,7 +36,6 @@ use zcash_client_backend::data_api::{
 };
 use zcash_client_backend::data_api::{WalletCommitmentTrees, Zip32Derivation};
 use zcash_client_backend::fees::standard::MultiOutputChangeStrategy;
-use zcash_client_backend::fees::zip317::SingleOutputChangeStrategy;
 use zcash_client_backend::fees::{DustOutputPolicy, SplitPolicy, StandardFeeRule};
 use zcash_client_backend::proposal::Proposal;
 use zcash_client_backend::proto::service::{
@@ -54,16 +50,21 @@ use zcash_primitives::transaction::fees::FeeRule;
 use zcash_primitives::transaction::TxId;
 use zcash_proofs::prover::LocalTxProver;
 
-use crate::error::Error::PcztCreate;
+
 use zcash_client_backend::sync::run;
-use zcash_primitives::legacy::keys::{NonHardenedChildIndex, TransparentKeyScope};
-use zcash_primitives::zip32;
-use zcash_primitives::zip32::fingerprint::SeedFingerprint;
-use zcash_protocol::consensus::{NetworkConstants, Parameters};
+
+use zip32;
+use zip32::fingerprint::SeedFingerprint;
+use zcash_protocol::consensus::Parameters;
 use zcash_protocol::value::Zatoshis;
 
 const BATCH_SIZE: u32 = 10000;
+
+/// constant that signals what's the minimum transparent balance for proposing a
+/// shielding transaction
 const SHIELDING_THRESHOLD: Zatoshis = Zatoshis::const_from_u64(100000);
+
+
 /// # A Zcash wallet
 ///
 /// A wallet is a set of accounts that can be synchronized together with the blockchain.

--- a/crates/webzjs-wallet/src/wallet.rs
+++ b/crates/webzjs-wallet/src/wallet.rs
@@ -64,7 +64,7 @@ use zcash_protocol::consensus::{NetworkConstants, Parameters};
 use zcash_protocol::value::Zatoshis;
 
 const BATCH_SIZE: u32 = 10000;
-
+const SHIELDING_THRESHOLD: Zatoshis = Zatoshis::const_from_u64(100000);
 /// # A Zcash wallet
 ///
 /// A wallet is a set of accounts that can be synchronized together with the blockchain.
@@ -469,10 +469,10 @@ where
             &self.network,
             &input_selector,
             &change_strategy,
-            Zatoshis::ZERO,
+            SHIELDING_THRESHOLD, // use a shielding threshold above a marginal fee transaction plus some value like Zashi does.
             &from_addrs,
             account_id,
-            0,
+            1, // librustzcash operates under the assumption of zero or one conf being the same but that could change.
         )
         .map_err(|e| Error::Generic(format!("Error when shielding: {:?}", e)))?;
 

--- a/packages/web-wallet/src/components/Button/Button.tsx
+++ b/packages/web-wallet/src/components/Button/Button.tsx
@@ -3,7 +3,7 @@ import cn from 'classnames';
 
 type ButtonVariant = 'primary' | 'secondary';
 
-interface ButtonProps {
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   onClick: () => void;
   label: string;
   classNames?: string;
@@ -17,10 +17,12 @@ function Button({
   classNames = '',
   variant = 'primary',
   icon,
+  ...rest
 }: ButtonProps) {
   const buttonClasses = cn(
     'min-w-[228px] px-6 py-3 rounded-3xl text-base font-medium leading-normal',
-    'cursor-pointer transition-all hover:transition-all',
+    'transition-all hover:transition-all',
+    { 'cursor-not-allowed': rest.disabled, 'cursor-pointer': !rest.disabled },
     {
       'bg-[#0e0e0e] text-white border hover:bg-buttonBlackGradientHover':
         variant === 'primary',
@@ -31,7 +33,7 @@ function Button({
   );
 
   return (
-    <button onClick={onClick} className={buttonClasses}>
+    <button onClick={onClick} className={buttonClasses} {...rest}>
       <div className="flex items-center justify-center">
         {icon && <span className="mr-2 flex items-center">{icon}</span>}
         <span>{label}</span>

--- a/packages/web-wallet/src/pages/ShieldBalance/ShieldBalance.tsx
+++ b/packages/web-wallet/src/pages/ShieldBalance/ShieldBalance.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { ZcashYellowPNG } from '../../assets';
 import PageHeading from '../../components/PageHeading/PageHeading';
 import useBalance from '../../hooks/useBalance';
@@ -45,6 +45,10 @@ export function ShieldBalance(): React.JSX.Element {
     handlePcztShieldTransaction(1, addresses.unifiedAddress, unshieldedBalance.toString());
   }
 
+  const isMinimalShieldAmount = useMemo(()=>{
+    return unshieldedBalance > 100000;
+  },[unshieldedBalance])
+
   return (
     <div className="flex flex-col w-full">
       <PageHeading title="Shield Balance">
@@ -88,11 +92,17 @@ export function ShieldBalance(): React.JSX.Element {
               </div>
             </div>
             <div className="self-stretch pt-6 flex-col justify-center items-center gap-3 flex">
-              <div className="justify-start items-start inline-flex">
+              <div className="flex flex-col items-center justify-center">
                 <Button
                   onClick={handleShieldBalance}
                   label={'Shield balance'}
+                  disabled={!isMinimalShieldAmount}
                 />
+                {!isMinimalShieldAmount && (
+                  <div className="text-red-500 text-sm mt-2">
+                    The minimum shielding balance required is 0.001 ZEC.
+                  </div>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Changes
- use zcash_protocol's networkType and remove unused variable
- change use of deprecated BalanceError in favor of zcash_protocol one
- Use Zip32 crate instead of re-pub of librustzcash (same version)
- remove usage of deprecated `ShieldedProtocol` in favor of `zcash_protocol` one
- remove NonNegativeAmount use in favor of Zatoshis
- Use shielding threshold as Zashi and Mobile SDKs do

## Tests
 No tests altered.
 
## Issues
https://github.com/ChainSafe/WebZjs/issues/106
Closes #106 