### PR TITLE
onInstall origin check, snap dialog returning null change

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ yarn
 
 ```shell
 cd packages/snap
-yarn build
+yarn build:local
 yarn serve
 ```
 

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ChainSafe/WebZjs.git"
   },
   "source": {
-    "shasum": "8Nspw4PiDnqHYCS32Dwpz7Ubo0J0ocBhXYPAvXM4Kew=",
+    "shasum": "H/WNtXmCGWcb0sWiaV65s4EzOAXLOybmIci9tffzCHc=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -78,6 +78,8 @@ export const onUserInput: OnUserInputHandler = async ({ id, event }) => {
   }
 };
 
-export const onInstall: OnInstallHandler = async () => {
+export const onInstall: OnInstallHandler = async (args) => {
+  if (args.origin === 'https://webzjs.chainsafe.dev') return;
+
   await installDialog();
 };

--- a/packages/snap/src/rpc/setBirthdayBlock.tsx
+++ b/packages/snap/src/rpc/setBirthdayBlock.tsx
@@ -53,12 +53,19 @@ export async function setBirthdayBlock({
     },
   });
 
-  const { customBirthdayBlock } = (await snap.request({
-    method: 'snap_dialog',
-    params: {
-      id: interfaceId,
-    },
-  })) as BirthdayBlockForm;
+  let customBirthdayBlock: string | null;
+  try {
+    const dialogResponse = (await snap.request({
+      method: 'snap_dialog',
+      params: {
+        id: interfaceId,
+      },
+    })) as BirthdayBlockForm;
+    customBirthdayBlock = dialogResponse.customBirthdayBlock;
+  } catch (error) {
+    console.log('No custom birthday block provided, using latest block');
+    customBirthdayBlock = null;
+  }
 
   const webWalletSyncStartBlock = setSyncBlockHeight(customBirthdayBlock, latestBlock);
 


### PR DESCRIPTION
-onInstall not triggering if user is already on https://webzjs.chainsafe.dev

-snap dialog now throws error if input remains empty on new MM version, fixed with same UX as before, if input remains null wallet birthday block is set to latest block