### PR TITLE
Introducing ZIP-48 Support, Secure Message Signing, and Public Key Retrieval

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -30,6 +30,9 @@
   "dependencies": {
     "@chainsafe/webzjs-keys": "0.1.0",
     "@metamask/snaps-sdk": "^6.17.1",
+    "@noble/hashes": "^1.4.0",
+    "@noble/secp256k1": "^2.1.0",
+    "bs58check": "^4.0.0",
     "buffer": "^6.0.3",
     "superstruct": "^2.0.2"
   },

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/ChainSafe/WebZjs.git"
   },
   "source": {
-    "shasum": "wTPZl0jiwxyFr3cUhss5/b0WjFGdZP9y/VIPafGtDAM=",
+    "shasum": "gR+0fkxHpNURVXHOtwC42+XPZys6n8nDX6ZdyQ3bwpo=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -29,6 +29,20 @@
     "snap_getBip44Entropy": [
       {
         "coinType": 133
+      }
+    ],
+    "snap_getBip32Entropy": [
+      {
+        "path": ["m", "48'", "133'"],
+        "curve": "secp256k1"
+      },
+      {
+        "path": ["m", "48'", "133'", "0'", "133000'", "0", "0"],
+        "curve": "secp256k1"
+      },
+      {
+        "path": ["m", "48'", "1'", "0'", "133000'", "0", "0"],
+        "curve": "secp256k1"
       }
     ],
     "snap_manageState": {}

--- a/packages/snap/src/index.tsx
+++ b/packages/snap/src/index.tsx
@@ -8,11 +8,21 @@ import {
 } from '@metamask/snaps-sdk';
 import { setBirthdayBlock } from './rpc/setBirthdayBlock';
 import { getSnapState } from './rpc/getSnapState';
-import { SetBirthdayBlockParams, SignPcztParams, SnapState } from './types';
+import {
+  SetBirthdayBlockParams,
+  SignPcztParams,
+  SignTransparentMessageParams,
+  SignTransparentParams,
+  SnapState,
+  TransparentPublicKeyParams,
+} from './types';
 import { setSnapState } from './rpc/setSnapState';
-import { signPczt } from './rpc/signPczt'
+import { signPczt } from './rpc/signPczt';
+import { signTransparent } from './rpc/signTransparent';
+import { getTransparentPublicKey } from './rpc/getTransparentPublicKey';
+import { signTransparentMessage } from './rpc/signTransparentMessage';
 
-import { assert, object, number, optional, string } from 'superstruct';
+import { assert, object, number, optional, string, array } from 'superstruct';
 import { getSeedFingerprint } from './rpc/getSeedFingerprint';
 import type { OnInstallHandler } from "@metamask/snaps-sdk";
 import { installDialog } from './utils/dialogs';
@@ -45,6 +55,30 @@ export const onRpcRequest: OnRpcRequestHandler = async ({ request, origin }) => 
         }),
       }));
       return await signPczt(request.params as SignPcztParams, origin);
+    case 'signTransparent':
+      assert(request.params, object({
+        derivationPath: string(),
+        sighashes: array(string()),
+        details: object({
+          toAddress: string(),
+          amount: string(),
+          network: string()
+        })
+      }));
+      return await signTransparent(request.params as SignTransparentParams, origin);
+    case 'signTransparentMessage':
+      assert(request.params, object({
+        derivationPath: string(),
+        message: string(),
+        network: optional(string()),
+        expectedAddress: optional(string())
+      }));
+      return await signTransparentMessage(request.params as SignTransparentMessageParams, origin);
+    case 'getTransparentPublicKey':
+      assert(request.params, object({
+        derivationPath: string()
+      }));
+      return await getTransparentPublicKey(request.params as TransparentPublicKeyParams, origin);
     case 'getSeedFingerprint':
       return await getSeedFingerprint();
     case 'setBirthdayBlock':

--- a/packages/snap/src/rpc/getTransparentPublicKey.tsx
+++ b/packages/snap/src/rpc/getTransparentPublicKey.tsx
@@ -1,0 +1,34 @@
+import { Box, Text } from '@metamask/snaps-sdk/jsx';
+import { ensureDerivationPath, requestPrivateKey, splitDerivationPath } from '../utils/derivation';
+import { getPublicKey } from '@noble/secp256k1';
+import { snapConfirm } from '../utils/dialogs';
+
+export async function getTransparentPublicKey({ derivationPath }: { derivationPath: string }, origin: string): Promise<string> {
+  ensureDerivationPath(derivationPath);
+
+  const confirmed = await snapConfirm({
+    title: 'Access to ZIP-48 public key',
+    prompt: (
+      <Box>
+        <Text>Origin: {origin}</Text>
+        <Text>Derivation path: {derivationPath}</Text>
+      </Box>
+    )
+  });
+
+  if (!confirmed) {
+    throw new Error('User rejected the request');
+  }
+
+  const pathSegments = splitDerivationPath(derivationPath);
+  const privateKey = await requestPrivateKey(pathSegments);
+  const publicKey = getPublicKey(privateKey, true);
+  return uint8ArrayToHex(publicKey);
+}
+
+function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+

--- a/packages/snap/src/rpc/signTransparent.tsx
+++ b/packages/snap/src/rpc/signTransparent.tsx
@@ -1,0 +1,116 @@
+import { Box, Divider, Heading, Text } from '@metamask/snaps-sdk/jsx';
+import { SignTransparentParams } from '../types';
+import { hexStringToUint8Array } from '../utils/hexStringToUint8Array';
+import { snapConfirm } from '../utils/dialogs';
+import { assert, array, object, optional, string } from 'superstruct';
+import { Signature, sign } from '@noble/secp256k1';
+import { ensureDerivationPath, requestPrivateKey, splitDerivationPath } from '../utils/derivation';
+import { ensureHmacSupport } from '../utils/secp256k1';
+
+const SIGHASH_ALL = 0x01;
+
+const SignTransparentStruct = object({
+  derivationPath: string(),
+  sighashes: array(string()),
+  details: object({
+    toAddress: string(),
+    amount: string(),
+    network: string()
+  }),
+  metadata: optional(
+    object({
+      redeemScript: optional(string())
+    })
+  )
+});
+
+export async function signTransparent(params: SignTransparentParams, origin: string): Promise<string[]> {
+  ensureHmacSupport();
+  assert(params, SignTransparentStruct);
+  ensureDerivationPath(params.derivationPath);
+
+  const confirmed = await snapConfirm({
+    title: 'Transparent transaction signing',
+    prompt: (
+      <Box>
+        <Heading>Transparent Multisig</Heading>
+        <Divider />
+        <Text>Origin: {origin}</Text>
+        <Text>Recipient: {params.details.toAddress}</Text>
+        <Text>Amount: {params.details.amount} ZEC</Text>
+        <Text>Network: {params.details.network}</Text>
+      </Box>
+    )
+  });
+
+  if (!confirmed) {
+    throw new Error('User rejected signing');
+  }
+
+  const derivationPathSegments = splitDerivationPath(params.derivationPath);
+  const privateKey = await requestPrivateKey(derivationPathSegments);
+
+  const signatures = params.sighashes.map((hashHex) => {
+    if (typeof hashHex !== 'string' || hashHex.length !== 64) {
+      throw new Error('Invalid sighash');
+    }
+    const digest = hexStringToUint8Array(hashHex);
+    const signature = sign(digest, privateKey);
+    const derSignature = signatureToDer(signature);
+    const fullSignature = new Uint8Array(derSignature.length + 1);
+    fullSignature.set(derSignature, 0);
+    fullSignature[derSignature.length] = SIGHASH_ALL;
+    return uint8ArrayToHex(fullSignature);
+  });
+
+  return signatures;
+}
+
+function uint8ArrayToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function signatureToDer(signature: Signature): Uint8Array {
+  const r = normalizeDerComponent(signature.r);
+  const s = normalizeDerComponent(signature.s);
+  const length = 2 + r.length + 2 + s.length;
+  const result = new Uint8Array(2 + length);
+  let offset = 0;
+  result[offset++] = 0x30;
+  result[offset++] = length;
+  result[offset++] = 0x02;
+  result[offset++] = r.length;
+  result.set(r, offset);
+  offset += r.length;
+  result[offset++] = 0x02;
+  result[offset++] = s.length;
+  result.set(s, offset);
+  return result;
+}
+
+function normalizeDerComponent(value: bigint): Uint8Array {
+  let hex = value.toString(16);
+  if (hex.length % 2 !== 0) {
+    hex = `0${hex}`;
+  }
+  const bytes = hexStringToUint8Array(hex);
+  let sliceIndex = 0;
+  while (
+    sliceIndex < bytes.length - 1 &&
+    bytes[sliceIndex] === 0x00 &&
+    (bytes[sliceIndex + 1] & 0x80) === 0
+  ) {
+    sliceIndex += 1;
+  }
+  const trimmed = bytes.slice(sliceIndex);
+  if ((trimmed[0] & 0x80) !== 0) {
+    const prefixed = new Uint8Array(trimmed.length + 1);
+    prefixed[0] = 0x00;
+    prefixed.set(trimmed, 1);
+    return prefixed;
+  }
+  return trimmed;
+}
+

--- a/packages/snap/src/rpc/signTransparentMessage.tsx
+++ b/packages/snap/src/rpc/signTransparentMessage.tsx
@@ -1,0 +1,175 @@
+import { Box, Divider, Heading, Text } from '@metamask/snaps-sdk/jsx';
+import { snapConfirm } from '../utils/dialogs';
+import {
+  SignTransparentMessageParams,
+  SignTransparentMessageResult,
+  TransparentNetwork,
+} from '../types';
+import { ensureDerivationPath, requestPrivateKey, splitDerivationPath } from '../utils/derivation';
+import { ensureHmacSupport } from '../utils/secp256k1';
+import { getPublicKey, sign, verify } from '@noble/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+import { ripemd160 } from '@noble/hashes/ripemd160';
+import bs58check from 'bs58check';
+import { Buffer } from 'buffer';
+
+const MESSAGE_MAGIC = 'Zcash Signed Message:\n';
+const COMPRESSED_KEY_FLAG = 4;
+const NETWORK_ORDER: TransparentNetwork[] = ['mainnet', 'testnet'];
+
+const P2PKH_PREFIX: Record<TransparentNetwork, number> = {
+  mainnet: 0x1cb8,
+  testnet: 0x1d25,
+};
+
+const textEncoder = new TextEncoder();
+
+export async function signTransparentMessage(
+  params: SignTransparentMessageParams,
+  origin: string,
+): Promise<SignTransparentMessageResult> {
+  ensureHmacSupport();
+  ensureDerivationPath(params.derivationPath);
+
+  const message = params.message ?? '';
+  if (message.length === 0) {
+    throw new Error('Message is empty; nothing to sign');
+  }
+
+  const network = normalizeNetwork(params.network);
+
+  const confirmed = await snapConfirm({
+    title: 'Sign message (transparent)',
+    prompt: (
+      <Box>
+        <Heading>Transparent Message Signing</Heading>
+        <Divider />
+        <Text>Origin: {origin}</Text>
+        <Text>Network: {network}</Text>
+        <Text>Derivation path: {params.derivationPath}</Text>
+        <Divider />
+        <Text>Message:</Text>
+        <Text>{truncateMultiline(message, 180)}</Text>
+      </Box>
+    ),
+  });
+
+  if (!confirmed) {
+    throw new Error('User rejected message signing');
+  }
+
+  const derivationPathSegments = splitDerivationPath(params.derivationPath);
+  const privateKey = await requestPrivateKey(derivationPathSegments);
+  const digest = buildMessageDigest(message);
+  const signature = sign(digest, privateKey);
+  const compactSignature = signature.toCompactRawBytes();
+  const recovery = signature.recovery ?? 0;
+
+  const signatureWithHeader = new Uint8Array(65);
+  signatureWithHeader[0] = 27 + recovery + COMPRESSED_KEY_FLAG;
+  signatureWithHeader.set(compactSignature, 1);
+
+  const publicKey = getPublicKey(privateKey, true);
+  const derivedAddress = deriveP2pkhAddress(publicKey, network);
+  console.log('derivedAddress SNAP', publicKey,derivedAddress);
+  const normalizedExpected = params.expectedAddress?.trim();
+  if (normalizedExpected && normalizedExpected !== derivedAddress) {
+    throw new Error('Derived address does not match the provided expectedAddress');
+  }
+  const onDeviceVerification = verify(signature, digest, publicKey);
+  console.log(
+    `[snap] Message signature verification for PK ${bytesToHex(publicKey)}: ${onDeviceVerification}`,
+  );
+
+  return {
+    signature: bytesToBase64(signatureWithHeader),
+    address: derivedAddress,
+    publicKey: bytesToHex(publicKey),
+    message,
+    derivationPath: params.derivationPath,
+    network,
+  };
+}
+
+function buildMessageDigest(message: string): Uint8Array {
+  const magicBytes = textEncoder.encode(MESSAGE_MAGIC);
+  const messageBytes = textEncoder.encode(message);
+  const payload = concatBytes([
+    encodeCompactSize(magicBytes.length),
+    magicBytes,
+    encodeCompactSize(messageBytes.length),
+    messageBytes,
+  ]);
+  return sha256(sha256(payload));
+}
+
+function encodeCompactSize(value: number): Uint8Array {
+  if (value < 0xfd) {
+    return Uint8Array.of(value);
+  }
+  if (value <= 0xffff) {
+    return Uint8Array.of(0xfd, value & 0xff, (value >> 8) & 0xff);
+  }
+  if (value <= 0xffffffff) {
+    return Uint8Array.of(
+      0xfe,
+      value & 0xff,
+      (value >> 8) & 0xff,
+      (value >> 16) & 0xff,
+      (value >> 24) & 0xff,
+    );
+  }
+  const big = BigInt(value);
+  const result = new Uint8Array(9);
+  result[0] = 0xff;
+  for (let i = 0; i < 8; i += 1) {
+    result[i + 1] = Number((big >> BigInt(8 * i)) & 0xffn);
+  }
+  return result;
+}
+
+function concatBytes(arrays: Uint8Array[]): Uint8Array {
+  const totalLength = arrays.reduce((sum, current) => sum + current.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  arrays.forEach((array) => {
+    result.set(array, offset);
+    offset += array.length;
+  });
+  return result;
+}
+
+function deriveP2pkhAddress(publicKey: Uint8Array, network: TransparentNetwork): string {
+  const prefix = P2PKH_PREFIX[network];
+  const hash = ripemd160(sha256(publicKey));
+  const payload = Buffer.allocUnsafe(2 + hash.length);
+  payload.writeUInt16BE(prefix, 0);
+  Buffer.from(hash).copy(payload, 2);
+  return bs58check.encode(payload);
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function truncateMultiline(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function normalizeNetwork(network?: TransparentNetwork): TransparentNetwork {
+  if (network && NETWORK_ORDER.includes(network)) {
+    return network;
+  }
+  return 'testnet';
+}
+
+

--- a/packages/snap/src/types.ts
+++ b/packages/snap/src/types.ts
@@ -10,6 +10,41 @@ export type SignPcztParams = {
   };
 };
 
+export type SignTransparentParams = {
+  derivationPath: string;
+  sighashes: string[];
+  details: {
+    toAddress: string;
+    amount: string;
+    network: string;
+  };
+  metadata?: {
+    redeemScript?: string;
+  };
+};
+
+export type TransparentPublicKeyParams = {
+  derivationPath: string;
+};
+
+export type TransparentNetwork = 'mainnet' | 'testnet';
+
+export type SignTransparentMessageParams = {
+  derivationPath: string;
+  message: string;
+  network?: TransparentNetwork;
+  expectedAddress?: string;
+};
+
+export type SignTransparentMessageResult = {
+  signature: string;
+  address: string;
+  publicKey: string;
+  message: string;
+  derivationPath: string;
+  network: TransparentNetwork;
+};
+
 export interface SnapState extends Record<string, Json> {
   webWalletSyncStartBlock: string;
 }

--- a/packages/snap/src/utils/derivation.ts
+++ b/packages/snap/src/utils/derivation.ts
@@ -1,0 +1,28 @@
+import { hexStringToUint8Array } from './hexStringToUint8Array';
+
+export function ensureDerivationPath(path: string): void {
+  if (!path || !path.startsWith('m/')) {
+    throw new Error('Derivation path must start with m/');
+  }
+}
+
+export function splitDerivationPath(path: string): string[] {
+  ensureDerivationPath(path);
+  return path.split('/').filter((segment) => segment.length > 0);
+}
+
+export async function requestPrivateKey(path: string[]): Promise<Uint8Array> {
+  const entropyNode = (await snap.request({
+    method: 'snap_getBip32Entropy',
+    params: {
+      path,
+      curve: 'secp256k1',
+    },
+  })) as { privateKey: string };
+
+  if (!entropyNode || typeof entropyNode.privateKey !== 'string') {
+    throw new Error('MetaMask did not return a private key for the specified path');
+  }
+
+  return hexStringToUint8Array(entropyNode.privateKey);
+}

--- a/packages/snap/src/utils/dialogs.tsx
+++ b/packages/snap/src/utils/dialogs.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from '@metamask/snaps-sdk/jsx';
 import { Box, Heading, Text, Link } from '@metamask/snaps-sdk/jsx';
 
 export const installDialog = async () => {
@@ -19,4 +20,27 @@ export const installDialog = async () => {
       ),
     },
   });
+};
+
+export const snapConfirm = async ({
+  title,
+  prompt
+}: {
+  title: string;
+  prompt: JSX.Element;
+}): Promise<boolean> => {
+  const result = await snap.request({
+    method: 'snap_dialog',
+    params: {
+      type: 'confirmation',
+      content: (
+        <Box>
+          <Heading>{title}</Heading>
+          {prompt}
+        </Box>
+      )
+    }
+  });
+
+  return Boolean(result);
 };

--- a/packages/snap/src/utils/secp256k1.ts
+++ b/packages/snap/src/utils/secp256k1.ts
@@ -1,0 +1,26 @@
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha256';
+import { etc } from '@noble/secp256k1';
+
+function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  if (arrays.length === 1) {
+    return arrays[0];
+  }
+  const totalLength = arrays.reduce((sum, current) => sum + current.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  arrays.forEach((array) => {
+    result.set(array, offset);
+    offset += array.length;
+  });
+  return result;
+}
+
+export function ensureHmacSupport(): void {
+  if (!etc.hmacSha256Sync) {
+    etc.hmacSha256Sync = (key: Uint8Array, ...msgs: Uint8Array[]) => {
+      const message = concatUint8Arrays(msgs);
+      return hmac(sha256, key, message);
+    };
+  }
+}


### PR DESCRIPTION
The snap now brings full ZIP-48 transparent multisig support with [Asigna](https://zec.asigna.io) into MetaMask Snaps by exposing new RPC methods that can be invoked via `wallet_invokeSnap`. Every method enforces well-formed ZIP-48 derivation paths (starting with `m/…`), derives keys through `snap_getBip32Entropy`, and displays a user-facing confirmation dialog before any sensitive action is performed.

- `signTransparent` – takes a list of transaction sighashes tied to a ZIP-48 derivation path, shows the recipient/amount/network to the user, and upon confirmation returns DER signatures with `SIGHASH_ALL`, ready to be assembled into the multisig transaction.
- `signTransparentMessage` – signs arbitrary text messages with the selected transparent key, applies ZIP-302 message framing, verifies the signature on-device, and optionally checks the derived address against a provided `expectedAddress` to prevent account mix-ups.
- `getTransparentPublicKey` – safely derives and returns the compressed public key for any ZIP-48 path after the user approves a dialog showing the origin and requested derivation path.

This makes the snap cover the full transparent ZIP-48 workflow—transaction signing, message signing, and key disclosure—with explicit user consent at each step.